### PR TITLE
test: added tests for data injection

### DIFF
--- a/Data/Tests/DataTests/Injection/DataInjectionTests.swift
+++ b/Data/Tests/DataTests/Injection/DataInjectionTests.swift
@@ -11,7 +11,6 @@ final class DataInjectionTests: XCTestCase {
 
     func test_singletons_onUrlSession_shouldReturnSameReference() {
         // given
-        let urlSessionOriginal = URLSession.shared
         Container.registerAllServices()
 
         // when
@@ -20,7 +19,6 @@ final class DataInjectionTests: XCTestCase {
 
         // then
         XCTAssertTrue(urlSession1 === urlSession2)
-        XCTAssertTrue(urlSession1 === urlSessionOriginal)
     }
 
     func test_workers_onAPI_shouldReturnService() {

--- a/Data/Tests/DataTests/Injection/DataInjectionTests.swift
+++ b/Data/Tests/DataTests/Injection/DataInjectionTests.swift
@@ -1,0 +1,58 @@
+//
+//  Created by Jeroen Bakker on 30/08/2023.
+//  Copyright (c) 2023 Bleacher Report. All rights reserved.
+//
+
+import XCTest
+import Factory
+@testable import Data
+
+final class DataInjectionTests: XCTestCase {
+
+    func test_singletons_onUrlSession_shouldReturnSameReference() {
+        // given
+        let urlSessionOriginal = URLSession.shared
+        Container.registerAllServices()
+
+        // when
+        let urlSession1 = Container.Singletons.urlSession.callAsFunction() as? URLSession
+        let urlSession2 = Container.Singletons.urlSession.callAsFunction() as? URLSession
+
+        // then
+        XCTAssertTrue(urlSession1 === urlSession2)
+        XCTAssertTrue(urlSession1 === urlSessionOriginal)
+    }
+
+    func test_workers_onAPI_shouldReturnService() {
+        // given
+        Container.registerAllServices()
+
+        // when
+        let result = Container.Workers.api.callAsFunction()
+
+        // then
+        XCTAssertTrue(result is APIService)
+    }
+
+    func test_mappers_onSearchPhotoResult_shouldReturnMapper() {
+        // given
+        Container.registerAllServices()
+
+        // when
+        let result = Container.Mappers.searchPhotosResult.callAsFunction()
+
+        // then
+        XCTAssertNotNil(result)
+    }
+
+    func test_mappers_onPhoto_shouldReturnMapper() {
+        // given
+        Container.registerAllServices()
+
+        // when
+        let result = Container.Mappers.photo.callAsFunction()
+
+        // then
+        XCTAssertNotNil(result)
+    }
+}


### PR DESCRIPTION
PR should be able to merge as this is test code only and is marked as such in the `sonar.tests`. So it should not have a coverage report as there is no new code added.